### PR TITLE
Fix bug in Operation.finish() where passed errors were not added to _…

### DIFF
--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -375,12 +375,12 @@ public class Operation: NSOperation, OperationDebuggable {
         if !hasFinishedAlready {
             hasFinishedAlready = true
             state = .Finishing
-            
-            let combinedErrors = _internalErrors + errors
-            finished(combinedErrors)
+
+            _internalErrors.appendContentsOf(errors)
+            finished(_internalErrors)
             
             for observer in observers {
-                observer.operationDidFinish(self, errors: combinedErrors)
+                observer.operationDidFinish(self, errors: _internalErrors)
             }
             
             state = .Finished


### PR DESCRIPTION
…internalErrors

Previously this was combining the _internalErrors with the passed in errors
and passing them along to finished() and observer.operationDidFinish(). This
causes problems with the NoFailedDependencies condition that inspects the
_internalErrors array.

Fixed this by making finish() store the passed errors in _internalErrors.
Calling Operation.finishWithError() ends up calling finish() with the
passed error.
